### PR TITLE
Fix buggy fling on android 7.1(N) in nestedscrollview

### DIFF
--- a/android/src/main/java/com/mohtada/nestedscrollview/ReactNestedScrollView.java
+++ b/android/src/main/java/com/mohtada/nestedscrollview/ReactNestedScrollView.java
@@ -24,6 +24,9 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.OverScroller;
 import android.widget.ScrollView;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.widget.ScrollerCompat;
+import java.lang.reflect.Method;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
@@ -184,6 +187,26 @@ public class ReactNestedScrollView extends NestedScrollView implements ReactClip
         }
 
         return false;
+    }
+
+    
+    @Override 
+    protected void onDraw(Canvas canvas) { 
+        super.onDraw(canvas); 
+
+        try { 
+            Field mScroller = NestedScrollView.class.getDeclaredField("mScroller"); 
+            mScroller.setAccessible(true); 
+
+            Method isFinishedMethod = ScrollerCompat.class.getDeclaredMethod("isFinished"); 
+            boolean isFinished = (boolean) isFinishedMethod.invoke(mScroller.get(this)); 
+
+            if (!isFinished) { 
+                ViewCompat.postInvalidateOnAnimation(this); 
+            } 
+        } catch (Exception e) { 
+            // No need for actions 
+        } 
     }
 
     @Override


### PR DESCRIPTION
Hi, thanks for your awesome library first. In android 7.1, nestedscrollview's fling is buggy as you can see here [post](https://chris.banes.me/2017/06/09/carry-on-scrolling/). This PR fix it by checking if the previous scroll is finished using Reflect.

Except using Reflect it seems like just simply updating support library to 26.0.0-alpha+ works but it fails in my case. Therefore I totally undestand if this PR is not going to be merged into source. Thanks in advance