### PR TITLE
Fixed incorrect fallback behavior on ios

### DIFF
--- a/index.js
+++ b/index.js
@@ -636,7 +636,7 @@ if (Platform.OS === 'android') {
             onScrollEndDrag: true,
         }
     };
-    RCTScrollView = requireNativeComponent('RCTNestedScrollView', ScrollView, nativeOnlyProps);
+    RCTScrollView = requireNativeComponent('RCTScrollView', ScrollView, nativeOnlyProps);
 }
 
 module.exports = ScrollView;


### PR DESCRIPTION
IOS does not have a native module RCTNestedScrollView, which was causing an error.